### PR TITLE
Match Published Ports on VM & Containers

### DIFF
--- a/ansible_playbooks/roles/sed/tasks/main.yml
+++ b/ansible_playbooks/roles/sed/tasks/main.yml
@@ -39,14 +39,14 @@
 
 #------Setup Application-------#
 - name: create docker consul
-  docker:
+  docker_container:
     image: consul:latest
     name: consul
   become: true
 
 #------Setup Application-------#
 - name: create docker vault
-  docker:
+  docker_container:
     image: vault:latest
     name: vault
   become: true
@@ -68,7 +68,7 @@
     update: true
 
 - name: start the mysql container
-  docker:
+  docker_container:
     image: mysql:latest
     name: sed_database
     publish_all_ports: true
@@ -95,7 +95,7 @@
   become: true
 
 - name: Start SED-Web-Application Container
-  docker:
+  docker_container:
     image: sed_image:latest
     name: sed_website
     publish_all_ports: true
@@ -113,7 +113,7 @@
   become: true
 
 - name: Start Kick Off Presentation Container
-  docker:
+  docker_container:
     image: sed_kick_off:latest
     name: sed_kickoff
     publish_all_ports: true

--- a/ansible_playbooks/roles/sed/tasks/main.yml
+++ b/ansible_playbooks/roles/sed/tasks/main.yml
@@ -71,7 +71,8 @@
   docker_container:
     image: mysql:latest
     name: sed_database
-    publish_all_ports: true
+    ports:
+    - 3306:3306
     env:
       MYSQL_DATABASE: sed_database
       MYSQL_USER: sed_admin
@@ -98,7 +99,8 @@
   docker_container:
     image: sed_image:latest
     name: sed_website
-    publish_all_ports: true
+    ports:
+    - 8000:8000
     links:
     - "sed_database"
   become: true
@@ -116,9 +118,8 @@
   docker_container:
     image: sed_kick_off:latest
     name: sed_kickoff
-    publish_all_ports: true
     ports:
-      "9000:8000"
+    - 9000:8000
   become: true
 #------Setup Presentation: Database-------#
 


### PR DESCRIPTION
This matches the published ports from containers to forwarded ports on the Vagrant VM for the database, website, and kickoff presentation.

Also, updates the Ansible script to use "docker_container" instead of the deprecated "docker" module.